### PR TITLE
Readme updated with steps to use bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A clone of unix ps program - reports a snapshot of the current processes; includ
 ```
 
 ## Install
-`gem install`
+`bundle install`
 
 ## Run
 Executable is `bin/ps.rb`


### PR DESCRIPTION
Hi @fredrb ,

Did you mean to use `bundle install` instead of `gem install`? In the case you want the users to be able to install using `gem install ps-clone`, you need to publish to Rubygems.org.

In the case you publish, maybe it is worth to just cancel this PR.

Cheers!
